### PR TITLE
Update for v12

### DIFF
--- a/module/actor-sheet.js
+++ b/module/actor-sheet.js
@@ -35,7 +35,8 @@ export class HoneyHeistActorSheet extends ActorSheet {
 
 		html.find(".attribute-roll").click(async (ev) => {
 			const roller = $(ev.currentTarget);
-			const roll = new Roll(roller.data("roll"), this.actor.getRollData()).evaluate({ async: false });  // avoid deprecation warning, backwards compatible
+			const roll = new Roll(roller.data("roll"), this.actor.getRollData());
+			await roll.evaluate();
 			const parent = roller.parent("div");
 			const label = parent.find("label").get(0).innerText;
 			const select = parent.find("select").get(0);
@@ -83,7 +84,8 @@ export class HoneyHeistActorSheet extends ActorSheet {
 			const roller = $(ev.currentTarget);
 			const input = roller.siblings(".stat-value").get(0);
 			const currentValue = parseInt(input.value);
-			const roll = new Roll(roller.data("roll"), this.actor.getRollData()).evaluate({ async: false });  // avoid deprecation warning, backwards compatible
+			const roll = new Roll(roller.data("roll"), this.actor.getRollData());
+			await roll.evaluate();
 			const isSuccess = roll.total <= currentValue;
 			const rollSuccess = isSuccess ? game.i18n.localize("HH.Success") : game.i18n.localize("HH.Failed");
 			const actionMessage = isSuccess
@@ -98,7 +100,7 @@ export class HoneyHeistActorSheet extends ActorSheet {
 			// GREED: When the plan goes off without a hitch, move
 			// one point from Bear into Criminal.
 			const isEnd = await this._updateStatsAsync(isSuccess ? -1 : 1, roll, isBearRoll);
-
+			
 			if (!isEnd) {
 				roll.toMessage({
 					user: game.user.id,  // avoid deprecation warning, backwards compatible

--- a/system.json
+++ b/system.json
@@ -1,31 +1,34 @@
 {
-	"id": "honey-heist",
-	"title": "Honey Heist",
-	"description": "It's HoneyCon. You are going to undertake the greatest heist the world has ever seen.",
-	"version": 1.5,
-	"templateVersion": 2,
-	"compatibility": {
-		"minimum": "10",
-		"verified": "10",
-		"maximum": ""
-	},
-	"authors": [
-		{
-			"name": "JHaywood"
-		}
-	],
-	"esmodules": [ "module/main.js" ],
-	"styles": [ "styles/main.css" ],
-	"packs": [],
-	"languages": [
-		{
-			"lang": "en",
-			"name": "English",
-			"path": "lang/en.json"
-		}
-	],
-	"url": "https://github.com/jbhaywood/foundryvtt-honeyheist/",
-	"manifest": "https://raw.githubusercontent.com/jbhaywood/foundryvtt-honeyheist/master/system.json",
-	"download": "https://github.com/jbhaywood/foundryvtt-honeyheist/archive/v1.5.zip",
-	"license": "LICENSE.txt"
+  "id": "honey-heist",
+  "title": "Honey Heist",
+  "description": "It's HoneyCon. You are going to undertake the greatest heist the world has ever seen.",
+  "version": "1.5",
+  "compatibility": {
+    "minimum": "10",
+    "verified": "12"
+  },
+  "authors": [
+    {
+      "name": "JHaywood",
+      "flags": {}
+    }
+  ],
+  "esmodules": [
+    "module/main.js"
+  ],
+  "styles": [
+    "styles/main.css"
+  ],
+  "languages": [
+    {
+      "lang": "en",
+      "name": "English",
+      "path": "lang/en.json",
+      "flags": {}
+    }
+  ],
+  "url": "https://github.com/jbhaywood/foundryvtt-honeyheist/",
+  "manifest": "https://raw.githubusercontent.com/jbhaywood/foundryvtt-honeyheist/master/system.json",
+  "download": "https://github.com/jbhaywood/foundryvtt-honeyheist/archive/v1.5.zip",
+  "license": "LICENSE.txt"
 }

--- a/system.json
+++ b/system.json
@@ -5,7 +5,8 @@
   "version": "1.5",
   "compatibility": {
     "minimum": "10",
-    "verified": "12"
+    "verified": "10",
+    "maximum": "12"
   },
   "authors": [
     {


### PR DESCRIPTION
The evaluate asynch was removed in v12. Splitting the evaluate function to it's own line with await seems to fix the system for v12. Not sure about backwards compatibility to previous versions though.