### PR TITLE
Add support for FoundryVTT v13

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -26,14 +26,14 @@ body {
   background: #dbcbbd;
 }
 .flavor-text {
-  color: #1a1c20;
+  color: @textColor;
 }
 h2 {
   font-family: Title;
-  border-bottom: 2px solid #1a1c20;
+  border-bottom: 2px solid @textColor;
 }
 input[type="text"] {
-  border: 1px solid #1a1c20;
+  border: 1px solid @textColor;
   border-radius: 0px;
   font-family: Title;
   font-size: 1.3em;
@@ -49,12 +49,15 @@ a:hover {
   text-shadow: 0 0 8px #87431d;
 }
 select,
-button,
-textarea,
-form button {
+textarea {
   font-family: Body;
   border-radius: 0;
-  border: 1px solid #290001;
+  border: 1px solid #dbcbbd;
+}
+button,
+form button {
+  border-radius: 0;
+  border: 1px solid #dbcbbd;
 }
 button:hover {
   box-shadow: 0 0 10px #87431d;
@@ -67,7 +70,7 @@ input,
 input[type="text"],
 input[type="password"],
 input[type="datetime-local"] {
-  color: #1a1c20;
+  color: @textColor;
 }
 .sheet-footer {
   margin-top: 10px;
@@ -77,7 +80,7 @@ input[type="datetime-local"] {
   color: #dbcbbd;
 }
 .window-content .fa-plus:before {
-  color: #1a1c20;
+  color: @textColor;
 }
 .tabs .item.active {
   text-shadow: 0 0 10px #87431d;
@@ -137,7 +140,7 @@ input[type="datetime-local"] {
   color: darkred !important;
 }
 .honeyheist .window-content {
-  color: #1a1c20;
+  color: @textColor;
   height: 100%;
   padding: 10px;
   overflow-y: auto;

--- a/styles/variables.less
+++ b/styles/variables.less
@@ -3,7 +3,8 @@
 @medDarkColor: #87431d;
 @mediumColor: #c87941;
 @lightColor: #dbcbbd;
-@textColor: #1a1c20;
+@textColorOld: #1a1c20;
+@textColor: #E0CBAF;
 
 @font-face {
 	font-family: Title;

--- a/system.json
+++ b/system.json
@@ -2,11 +2,11 @@
   "id": "honey-heist",
   "title": "Honey Heist",
   "description": "It's HoneyCon. You are going to undertake the greatest heist the world has ever seen.",
-  "version": "1.61",
+  "version": "1.71",
   "compatibility": {
     "minimum": "10",
-    "verified": "12",
-    "maximum": "12"
+    "verified": "13",
+    "maximum": "13"
   },
   "authors": [
     {
@@ -30,6 +30,6 @@
   ],
   "url": "https://github.com/jbhaywood/foundryvtt-honeyheist/",
   "manifest": "https://raw.githubusercontent.com/jbhaywood/foundryvtt-honeyheist/master/system.json",
-  "download": "https://github.com/jbhaywood/foundryvtt-honeyheist/archive/v1.61.zip",
+  "download": "https://github.com/jbhaywood/foundryvtt-honeyheist/archive/v1.71.zip",
   "license": "LICENSE.txt"
 }


### PR DESCRIPTION
Adds basic support for FoundryVTT v13:
- Recolors some text and outlines for UI buttons to adapt to the new ui schema in v13
- Removes `font-family: Body;` from UI buttons to allow for compatibility with Font Awesome 6

Left to do:
- globalThis.isNewerVersion which must now be accessed via foundry.utils.isNewerVersion (deprecated in V12)
- the global "ActorSheet" which is now namespaced under foundry.appv1.sheets.ActorSheet (deprecated in V13)
- the global "ItemSheet" which is now namespaced under foundry.appv1.sheets.ItemSheet (deprecated in V13)
- the global "Actors" which is now namespaced under foundry.documents.collections.Actors (deprecated in V13)
- the global "Items" which is now namespaced under foundry.documents.collections.Items (deprecated in V13)
- The {{select}} handlebars helper is deprecated in favor of using the {{selectOptions}} helper (deprecated in V12)
- globalThis.mergeObject which must now be accessed via foundry.utils.mergeObject (deprecated in V12)

Known Issues:
- Actor Icons are too small
- Scene Thumbnails are too small
- Left hand side UI buttons are off center and/or wrong size in drop shadow box